### PR TITLE
Have test specs files use .name property instead of hardcoded string

### DIFF
--- a/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
+++ b/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { <%= classify(name) %><%= classify(type) %> } from './<%= dasherize(name) %><%= type ? '.' + dasherize(type): '' %>';
 
-describe('<%= classify(name) %><%= classify(type) %>', () => {
+describe(<%= classify(name) %><%= classify(type) %>.name, () => {
   let component: <%= classify(name) %><%= classify(type) %>;
   let fixture: ComponentFixture<<%= classify(name) %><%= classify(type) %>>;
 


### PR DESCRIPTION
When using the angular schematic for generating components, this is always using a hardcoded string instead of a .name property for the class name, which will enormously help with the renaming tools.