### PR TITLE
Fix standalone check in the component-spec

### DIFF
--- a/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
+++ b/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
@@ -8,7 +8,7 @@ describe('<%= classify(name) %><%= classify(type) %>', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      <%= standalone ? 'imports' : 'declarations' %>: [<%= classify(name) %><%= classify(type) %>]
+      <%= (standalone === false) ? 'declarations' : 'imports' %>: [<%= classify(name) %><%= classify(type) %>]
     })
     .compileComponents();
 


### PR DESCRIPTION
`standalone` used to default to `false` but now defaults to `true`

- `true` or `undefined` => `imports`
- `false` => `declarations`

See [this](https://stackoverflow.com/questions/79743243/angular-cli-generated-component-test-files-are-still-modular) stackoverflow question